### PR TITLE
fix: Unsafe cross-origin anchor

### DIFF
--- a/pages/donate.tsx
+++ b/pages/donate.tsx
@@ -20,7 +20,7 @@ const DonatePage: React.FC = () => {
                 PayPal
               </Typography>
               <Link passHref href="https://paypal.me/karelkoudelka">
-                <a target="_blank">
+                <a target="_blank" rel="noopener">
                   <Button variant="outlined">paypal.me/karelkoudelka</Button>
                 </a>
               </Link>

--- a/pages/support.tsx
+++ b/pages/support.tsx
@@ -25,7 +25,7 @@ const Page: React.FC = () => {
                 Založ issue na GitHubu
               </Typography>
               <Link href="https://github.com/delta-craft/issue-tracker/issues">
-                <a target="_blank">
+                <a target="_blank" rel="noopener">
                   <Button variant="outlined">GitHub Issues</Button>
                 </a>
               </Link>


### PR DESCRIPTION
Why is this unsafe? https://web.dev/external-anchors-use-rel-noopener/